### PR TITLE
change logback version to 1.3.0

### DIFF
--- a/src/main/resources/fileTemplates/internal/ktorkoin_gradle.properties.ft
+++ b/src/main/resources/fileTemplates/internal/ktorkoin_gradle.properties.ft
@@ -5,7 +5,7 @@ serializationVersion=${serialization_version}
 #Dependencies
 systemProp.kvisionVersion=${kvision_version}
 ktorVersion=${ktor_version}
-logbackVersion=1.4.0
+logbackVersion=1.3.0
 
 kotlin.mpp.stability.nowarn=true
 kotlin.js.compiler=${compiler_backend}


### PR DESCRIPTION
LogbackServiceProvider has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0